### PR TITLE
bugfix: 规避旧文件和新文件数量不一致导致文件被覆盖的问题

### DIFF
--- a/EpisodeReName.py
+++ b/EpisodeReName.py
@@ -692,7 +692,7 @@ if os.path.isdir(target_path):
             file_name, ext = get_file_name_ext(name)
 
             # 只处理特定后缀
-            if not ext.lower() in ['jpg', 'png', 'nfo', 'torrent']:
+            if not ext.lower() in ['jpg', 'png', 'nfo', 'torrent', 'bak']:
                 continue
 
             res = re.findall('^S(\d{1,4})E(\d{1,4}(\.5)?)', file_name.upper())
@@ -700,7 +700,8 @@ if os.path.isdir(target_path):
                 continue
             else:
                 logger.info(f'{file_path}')
-                os.remove(file_path)
+                # os.remove(file_path)
+                os.rename(file_path, file_path + '.bak')
 
     # 遍历文件夹
     for root, dirs, files in os.walk(target_path, topdown=False):

--- a/EpisodeReName.py
+++ b/EpisodeReName.py
@@ -692,7 +692,7 @@ if os.path.isdir(target_path):
             file_name, ext = get_file_name_ext(name)
 
             # 只处理特定后缀
-            if not ext.lower() in ['jpg', 'png', 'nfo', 'torrent', 'bak']:
+            if not ext.lower() in ['jpg', 'png', 'nfo', 'torrent']:
                 continue
 
             res = re.findall('^S(\d{1,4})E(\d{1,4}(\.5)?)', file_name.upper())
@@ -700,8 +700,7 @@ if os.path.isdir(target_path):
                 continue
             else:
                 logger.info(f'{file_path}')
-                # os.remove(file_path)
-                os.rename(file_path, file_path + '.bak')
+                os.remove(file_path)
 
     # 遍历文件夹
     for root, dirs, files in os.walk(target_path, topdown=False):

--- a/EpisodeReName.py
+++ b/EpisodeReName.py
@@ -791,6 +791,13 @@ if rename_delay:
 
 logger.info(f"{'file_lists', file_lists}")
 
+# 检查旧的文件数量和新的文件数量是否一致，防止文件被覆盖
+old_list = set([x[0] for x in file_lists])
+new_list = set([x[1] for x in file_lists])
+if len(old_list) != len(new_list):
+    logger.warning(f"{'旧文件数量和新文件数量不一致，可能会被覆盖。请检查文件命名'}")
+    sys.exit()
+
 # 错误记录
 error_logs = []
 


### PR DESCRIPTION
遇到某些不规范的命名，可能导致生成的 new file name 是一样的，多个文件会被覆盖为一个文件，如这个资源的命名：
```
汪汪队立大功
└── S03
    ├── 汪汪队S03_01.mp4
    ├── 汪汪队S03_02.mp4
    └── 汪汪队S03_03.mp4
```
执行重命名工具后，文件只剩下`S03E03.mp4`文件。

该 MR 将 old 和 new 文件列表用 set 去重并对比总长度，两者一致再进行后续步骤

